### PR TITLE
fix build proxyv2 image step in CI

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -3,32 +3,28 @@
 # Usage:
 # ./.github/workflows/build.sh 
 
-# this script will modified upper directory istio-proxy repo
-# if self-used should attention that whether the upper directory have its own developing istio.proxy
 #first build should give permission to docker volumes
 #sudo chmod -R 777 /var/lib/docker/volumes
 
 set -e
 
 UPDATE_BRANCH=${UPDATE_BRANCH:-"master"}
-cd ..
 rm -rf istio-proxy
 git clone -b ${UPDATE_BRANCH} https://github.com/intel/istio-proxy.git
-cp -rf istio/ istio-proxy/ 
-cd istio-proxy
 
+pushd istio-proxy
 # Update to release branch as intel/envoy has updated.
 ./scripts/update_envoy.sh
 BUILD_WITH_CONTAINER=1 make build_envoy 
 BUILD_WITH_CONTAINER=1 make exportcache
+popd
 
-cd istio
+# SGX_BUILD_CONTAINER is not needed anymore.
+unset IMG
 # export env
 TAG=${TAG:-"pre-build"}
 make build
 # replace upstream envoy with local envoy in build proxyv2 image
-cd  ..
-cp -rf out/linux_amd64/envoy istio/out/linux_amd64/release/envoy
+cp -rf istio-proxy/out/linux_amd64/envoy out/linux_amd64/release/envoy
 # build proxyv2 image
-cd istio
 make docker.proxyv2


### PR DESCRIPTION
Signed-off-by: Xiao, Ziyang <ziyang.xiao@intel.com>

**Please provide a description of this PR:**

Fix build failed :https://github.com/intel/istio/actions/runs/3133563651

Because SGX_BUILD_CONTAINER caused build failed when build proxy image, I unset IMG in build.sh which will let SGX_BUILD_CONTAINER only used in build envoy binary step.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
