### PR TITLE
Fixed trigger event for tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,12 +42,12 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push Containers
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && github.ref_type != 'tag' }}
       run: |
         make push
 
     - name: Push Container Proxyv2
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && github.ref_type != 'tag' }}
       run: |
         docker push ${HUB}/proxyv2:${TAG}
 
@@ -59,9 +59,8 @@ jobs:
         TAG: ${{ github.ref_name }}
 
     - name: Push Container Proxyv2 With Tag
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.ref_type == 'tag' }}
       run: |
         docker push ${HUB}/proxyv2:${TAG}
       env:
         TAG: ${{ github.ref_name }}
-


### PR DESCRIPTION
Signed-off-by: Xiao, Ziyang <ziyang.xiao@intel.com>

**Please provide a description of this PR:**
I checked that when we add a tag, the push event also be triggered .That means when tag event will push image twice. So I add a judge that when tagged the push event should be skipped.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
