### PR TITLE
Docs site autogeneration and deployment to gh-pages

### DIFF
--- a/.github/workflows/autogen-and-deploy-docs-site.yaml
+++ b/.github/workflows/autogen-and-deploy-docs-site.yaml
@@ -1,0 +1,61 @@
+name: Generate and deploy docs site
+
+on:
+  push:
+    branches: [ 'release-*-intel' ]
+  workflow_dispatch: #Trigger manually from repo
+
+permissions:
+  contents: read
+
+jobs:
+
+  autogen-and-deploy-docs-site:
+
+    permissions:
+      contents: write
+    runs-on: self-hosted
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install -U sphinx
+          python3 -m pip install recommonmark sphinx_rtd_theme sphinx-markdown-tables
+
+      - name: Setup docs output direcotry
+        run: |
+          rm -rf $HOME/output
+          mkdir $HOME/output
+          touch $HOME/output/.nojekyll
+
+      - name: Set up git
+        run: |
+          echo $(git version)
+          author=$(git --no-pager log --format=format:'%an' -n 1)
+          email=$(git --no-pager log --format=format:'%ae' -n 1)
+          git config --global user.name "$author"
+          git config --global user.email "$email"
+
+      - name: Build sphinx
+        run: |
+          cd intel
+          sphinx-build -M html . _build
+          cp docs/index.html _build/html/index.html
+          mv _build/html/* $HOME/output/
+          echo 'successfully updated docs'
+
+      - name: Deploy docs to GH pages
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd $HOME/output
+          git init
+          git add .
+          git commit -m "latest html output for docs"
+          git push -f https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git HEAD:gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ var/
 ._*
 # MacOS Desktop Services Store
 .DS_Store
+# Sphinx documentation site
+_build
+_static
+_templates

--- a/intel/README.md
+++ b/intel/README.md
@@ -1,0 +1,24 @@
+# Intel managed distribution of Istio
+
+Intel managed distribution of Istio is a project aiming to showcase and integrate various Intel technologies into Istio and Envoy. The focus is in letting both upstream community and users know what Intel is working on, finding gaps in upstream project features in relation to hardware enablement, and testing and deploying Intel features for Istio service mesh.
+
+## Features
+
+* [TLS handshake acceleration with AVX512 (CryptoMB)](docs/CRYPTOMB.md)
+* [TLS handshake acceleration with QAT2.0](docs/QAT.md)
+* [HTTP data compression acceleration with QAT2.0](docs/QAT.md)
+* [Private key protection with SGX](docs/SGX-mTLS.md)
+
+## Supported versions
+* Kubernetes v1.24
+* Istio v1.15
+* cert-manager v1.7 or later
+* Linux kernel 5.18 or later
+* Intel Device Plugins for Kubernetes v0.24
+
+## Install
+
+Use the follwoing command for basic installation:
+
+```bash
+istioctl install --set hub=docker.io/intel --set tag=1.15.1-intel.0

--- a/intel/conf.py
+++ b/intel/conf.py
@@ -1,0 +1,27 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Intel managed distribution of Istio'
+copyright = '2022, various'
+author = 'various'
+html_title = 'Intel managed distribution of Istio'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['recommonmark', 'sphinx_rtd_theme', 'sphinx_markdown_tables']
+source_suffix = {'.rst': 'restructuredtext','.md': 'markdown'}
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+#html_static_path = ['_static']

--- a/intel/docs/CRYPTOMB.md
+++ b/intel/docs/CRYPTOMB.md
@@ -1,0 +1,30 @@
+# Istio acceleration with Intel® AVX512 crypto instructions
+
+## Introduction
+
+Cryptographic operations are among the most compute-intensive and critical operations when it comes to secured connections. Istio uses Envoy as the “gateways/sidecar” to handle secure connections and intercept the traffic.
+
+Depending upon use cases, when an ingress gateway must handle a large number of incoming TLS and secured service-to-service connections through sidecar proxies, the load on Envoy increases. The potential performance depends on many factors, such as size of the cpuset on which Envoy is running, incoming traffic patterns, and key size. These factors can impact Envoy serving many new incoming TLS requests. In this document you will learn how to enable CryptoMB in Istio to achieve performance improvements and accelerated handshakes.
+
+CryptoMB means using Intel® Advanced Vector Extensions 512 (Intel® AVX-512) instructions using a SIMD (single instruction, multiple data) mechanism. Up to eight RSA or ECDSA operations are gathered into a buffer and processed at the same time, providing potentially improved performance. Intel AVX-512 instructions are available on recently launched 3rd generation Intel Xeon Scalable processor server processors, or later.
+
+## Prerequisites
+
+- Kubernetes cluster with at least one node 3rd generation Intel Xeon Scalable processor server processors, or later.
+- Istio 1.14, or later
+
+## Install
+
+Use the following command for the installation:
+
+```bash
+istioctl install -y -f istio/istio-intel-cryptomb.yaml
+```
+
+With the above installation, CryptoMB acceleration is used both in `istio-ingress-gateway` and `istio-proxy` sidecar containers.
+
+## See also
+
+[CryptoMB - TLS handshake acceleration for Istio](https://istio.io/latest/blog/2022/cryptomb-privatekeyprovider)
+
+[A snapshot of Intel’s contributions to Istio](https://www.intel.com/content/www/us/en/developer/articles/technical/a-snapshot-of-contributions-to-istio.html)

--- a/intel/docs/QAT.md
+++ b/intel/docs/QAT.md
@@ -1,0 +1,118 @@
+# Istio crypto and compression acceleration with QAT
+
+## Introduction
+
+Intel® QuickAssist Technology (QAT) provides hardware acceleration for offloading security, authentication and compression services from the CPU, thus significantly increasing the performance and efficiency of standard platform solutions.
+
+In this guide you will install Istio with the following QAT features enabled:
+
+- QAT crypto acceleration for TLS handshakes
+- QAT compression acceleration for HTTP(s) data
+
+This solution is based on Linux in-tree driver and is utilizing the [qatlib](https://github.com/intel/qatlib)  and [qatzip](https://github.com/intel/qatzip) libraries.
+
+## Acronyms
+
+| Acronym | Description             |
+|---------| ------------------------|
+| QAT     | Intel® QuickAssist Technology Gen 4 avaialble in Sapphire Rapids CPUs |  
+| cy      | Cryptographic |
+| dc      | Compression |
+
+## Prerequisites
+
+Your Kubernetes nodes requires the following preparations
+
+- Install Linux kernel 5.17 or similar (TBD)
+- Enable IOMMU from BIOS (TBD)
+- Enable IOMMU for Linux kernel
+- Add QAT firmware
+- Enhance the container runtime memory lock limit
+- Install [Intel® QAT Device Plugin for Kubernetes](https://github.com/intel/intel-device-plugins-for-kubernetes)
+
+To enable IOMMU for Linux kernel, add the following change and commands:
+
+```console
+cat /etc/default/grub:
+GRUB_CMDLINE_LINUX="intel_iommu=on vfio-pci.ids=8086:4941"
+update-grub
+reboot
+````
+
+Once the system is rebooted, check if the IOMMU has been enabled via the following command:
+
+```console
+dmesg| grep IOMMU
+[    1.528237] DMAR: IOMMU enabled
+```
+
+To add QAT firmware, copy the [firmware](../files/qat20-fw-stepping-e.tgz) to the host machine and run the below commands.
+
+> NOTE: This is for steppig 6 (E)
+
+```console
+tar xzf qat20-fw-stepping-e.tgz
+sudo cp QAT20/quickassist/qat/fw/e/qat_4xxx.bin /usr/lib/firmware/
+sudo cp QAT20/quickassist/qat/fw/qat_4xxx_mmp.bin /usr/lib/firmware/
+sudo rmmod qat_4xxx
+sudo modprobe qat_4xxx
+```
+
+To enhance the `containerd` runtime memory lock limit, add the following file (CRIO has similar configuration):
+
+```console
+sudo mkdir /etc/systemd/system/containerd.service.d
+sudo bash -c 'cat <<EOF >>/etc/systemd/system/containerd.service.d/memlock.conf
+[Service]
+LimitMEMLOCK=16777216
+EOF'
+```
+
+Restart the container runtime (for containerd, CRIO has similar concept)
+
+```console
+sudo systemctl daemon-reload
+sudo systemctl restart containerd
+```
+
+## Istio install with QAT
+
+Use the following command for the Istio installation:
+
+```bash
+istioctl install -y -f istio/istio-intel-qat-hw.yaml
+```
+
+The above command allocates single crypto (`qat.intel.com/cy`) and compression (`qat.intel.com/dc`) QAT endpoint for the `istio-ingress-gateway`. In addition, it defines Istio sidecar injection template (`sidecarInjectorWebhook`) for the sidecar QAT endpoint allocation. 
+
+At this stage, the `istio-ingress-gateway` is ready for QAT crypto acceleration for TLS handshakes.
+
+To allocate QAT crypto endpoint for sidecars, add the following annotation to Kubernetes pods and/or deployments:
+
+```console
+inject.istio.io/templates: sidecar,qathw-crypto
+```
+
+With this annotation, the Istio sidecars are ready for QAT crypto acceleration for TLS handshakes.
+
+To allocate QAT compression endpoint for sidecars, add the following annotation to Kubernetes pods and/or deployments:
+
+```console
+inject.istio.io/templates: sidecar,qathw-compression
+```
+
+Enable QAT compression acceleration for `istio-ingress-gateway`:
+
+```console
+kubectl apply -f qat/qat-compression-envoy-filter.yaml
+```
+
+At this stage, the `istio-ingress-gateway` is ready for QAT compression acceleration for HTTP(s) data.
+
+Enable QAT compression acceleration for `istio-proxy` sidecars:
+
+```console
+kubectl apply -f  qat/compression-decompression-sidecar-envoy-filter.yaml
+```
+
+At this stage, the Istio sidecars are ready for QAT compression acceleration for HTTP(s) data.

--- a/intel/docs/SGX-mTLS.md
+++ b/intel/docs/SGX-mTLS.md
@@ -1,0 +1,94 @@
+# Istio mTLS Private Key Protection with SGX
+
+## Introduction
+
+Protecting Istio mTLS private keys with Intel® SGX enhances the service mesh security. The private keys are stored and used inside the SGX enclave(s) and will never stored in clear anywhere in the system. Authorized applications use the private key in the enclave by key-handle provided by SGX.
+
+## Prerequisites
+
+Prerequisites for using Istio mTLS private key protection with SGX:
+
+- Kubernetes cluster with one or more nodes with Intel® [SGX](https://software.intel.com/content/www/us/en/develop/topics/software-guard-extensions.html) supported hardware
+- [Intel® SGX device plugin](https://github.com/intel/intel-device-plugins-for-kubernetes/blob/main/cmd/sgx_plugin/README.md) for Kubernetes
+- [Intel® SGX AESM daemon](https://github.com/intel/linux-sgx#install-the-intelr-sgx-psw)
+- Linux kernel version 5.11 or later on the host (in tree SGX driver)
+
+## Installation
+
+This section covers how to install Istio mTLS private key protection with SGX
+
+1. Install Istio
+
+> NOTE: for the below command you need to use the `istioctl` for the `docker.io/intel/istioctl:1.15.1-intel.0` since only that contains Istio manifest enhancements for SGX mTLS.
+
+You can also customize the `istio-config.yaml` according to your needs. If you want to enable sgx in sidecars or gateway, you can set the `sgx.enable` flag as `true`. And if you want do the quote verification, you should enable the `certExtensionValidationEnabled` flag.
+
+```sh
+istioctl install -f ./sgx-mTLS/istio-config.yaml -y
+```
+
+2. Verifiy the pods are running
+
+By deault, `Istio` will be installed in the `istio-system` namespce
+
+```sh
+# Ensure that the pod is running state
+$ kubectl get po -n istio-system
+NAME                                    READY   STATUS    RESTARTS   AGE
+istio-egressgateway-66b7c87ff8-qdf2z    1/1     Running   0          24s
+istio-ingressgateway-789bb4b4f5-7mrq9   1/1     Running   0          24s
+istiod-6d49576478-cg6xc                 1/1     Running   0          28s
+```
+
+## Deploy sample application
+
+1. Create test namespace:
+
+```sh
+# create test namespace
+$ kubectl create ns foo
+```
+
+2. Create httpbin deployment:
+
+```sh
+kubectl apply -f <(istioctl kube-inject -f https://raw.githubusercontent.com/istio/istio/master/samples/httpbin/httpbin.yaml) -n foo
+```
+
+3. Create sleep deployment:
+
+```sh
+kubectl apply -f <(istioctl kube-inject -f https://raw.githubusercontent.com/istio/istio/master/samples/sleep/sleep.yaml) -n foo
+```
+
+4. Successful deployment looks like this:
+
+```sh
+$ kubectl get po -n foo
+NAME                       READY   STATUS    RESTARTS   AGE
+httpbin-7484c67b4d-8xf7q   2/2     Running     0        4m58s
+sleep-6b74fd544d-q64j8     2/2     Running     0        5m13s
+```
+5. Test pod resources:
+
+```sh
+$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl -s http://httpbin.foo:8000/headers | grep X-Forwarded-Client-Cert
+    "X-Forwarded-Client-Cert": "By=spiffe://cluster.local/ns/foo/sa/httpbin;Hash=cd5d0504234e80c701c4fe01ef49f3fe048a63d1cdd5b9ffe3dd67ae3d93396b;Subject=\"CN=spiffe://cluster.local/ns/foo/sa/sleep\";URI=spiffe://cluster.local/ns/foo/sa/sleep"
+
+```
+
+The above `httpbin` and `sleep` applications have enabled SGX and store the private keys inside SGX enclave, completed the TLS handshake and established a connection with each other and communicating normally.
+
+## Cleaning Up
+```sh
+# uninstall istio
+$ istioctl x uninstall --purge -y
+# delete workloads
+$ kubectl delete ns foo
+```
+
+## See also
+
+[Trusted Certificate Issuer](https://github.com/intel/trusted-certificate-issuer)
+
+[Trusted Attestation Controller](https://github.com/intel/trusted-attestation-controller)

--- a/intel/docs/index.html
+++ b/intel/docs/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; URL='README.html'" />

--- a/intel/index.rst
+++ b/intel/index.rst
@@ -1,0 +1,5 @@
+.. toctree::
+   README
+   docs/QAT
+   docs/CRYPTOMB
+   docs/SGX-mTLS

--- a/intel/yaml/intel-istio-cryptomb.yaml
+++ b/intel/yaml/intel-istio-cryptomb.yaml
@@ -1,0 +1,57 @@
+# Feature: TLS handshake acceleration using Icelake crypto multibuffers (avx512)
+# Requires: Icelake CPU, or later
+# Applies: Istio ingress gateway and sidecars
+
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  profile: default
+  tag: 1.15.1-intel.0
+  hub: docker.io/intel
+  meshConfig:
+    defaultConfig:
+      proxyStatsMatcher:
+        inclusionPrefixes:
+          - "listener"
+      # Allows cryptomb bucket statistics via EnvoyFilter 
+      proxyMetadata:
+        BOOTSTRAP_XDS_AGENT: "true"
+
+  components:
+    ingressGateways:
+    - enabled: true
+      name: istio-ingressgateway
+      k8s:
+        overlays:
+          - kind: Deployment
+            name: istio-ingressgateway
+            patches:
+            - path: spec.template.spec.containers.[name:istio-proxy].args.[-1]
+              value: "--concurrency=2"
+        # Limit CPU/MEM usage to 2 vCPUs/4 GB for QoS class of guaranteed.
+        # Enable CPU manager static policy in kubelet to even more deterministic results.
+        resources:
+          requests:
+            cpu: 2000m
+            memory: 4096Mi
+          limits:
+            cpu: 2000m
+            memory: 4096Mi
+        podAnnotations: # this controls the SDS service which configures ingress gateway
+          proxy.istio.io/config: |
+            privateKeyProvider:
+              cryptomb:
+                pollDelay: 10ms
+  values:
+    # Annotate pods with
+    #     inject.istio.io/templates: sidecar,cryptomb
+    #
+    # Note: CryptoMB doesn't have any method for guiding the workload to
+    # an AVX-512 enabled node, so when you annotate the pod with the
+    # cryptomb annotation, also set the taints correctly.
+    sidecarInjectorWebhook:
+      templates:
+        cryptomb: |
+          spec:
+            containers:
+            - name: istio-proxy

--- a/intel/yaml/intel-istio-dqx-mTLS.yaml
+++ b/intel/yaml/intel-istio-dqx-mTLS.yaml
@@ -1,0 +1,42 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  profile: minimal
+  hub: "docker.io/intel"
+  tag: "1.15.1-intel.0"
+  values:
+    global:
+      proxy:
+        sgx:
+          enabled: true
+          certExtensionValidationEnabled: true
+    gateways:
+      sgx:
+        enabled: true
+        certExtensionValidationEnabled: true
+  meshConfig:
+    accessLogFile: /dev/stdout
+    enableTracing: true
+    defaultConfig:
+      proxyMetadata:
+        # Enable basic DNS proxying
+        ISTIO_META_DNS_CAPTURE: "true"
+        # Enable automatic address allocation, optional
+        ISTIO_META_DNS_AUTO_ALLOCATE: "true"
+        # RSA or ECDSA 
+        # ECC_SIGNATURE_ALGORITHM: ECDSA
+
+  components:
+    pilot:
+      k8s:
+        imagePullPolicy: IfNotPresent
+    ingressGateways:
+    - name: istio-ingressgateway
+      enabled: true
+      k8s:
+        imagePullPolicy: IfNotPresent
+    egressGateways:
+    - name: istio-egressgateway
+      enabled: true
+      k8s:
+        imagePullPolicy: IfNotPresent

--- a/intel/yaml/intel-istio-qat-hw.yaml
+++ b/intel/yaml/intel-istio-qat-hw.yaml
@@ -1,0 +1,77 @@
+# Feature: TLS handshake acceleration using QAT2.0 crypto
+# Config: Envoy + BoringSSL + QAT2.0 
+# Requires: Sapphire Rapids CPU
+# Applies: Istio ingress gateway and sidecars
+
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: qat
+  namespace: istio-system
+spec:
+  profile: default
+  tag: 1.15.1-intel.0
+  hub: docker.io/intel
+  
+  components:
+    ingressGateways:
+    - name: istio-ingressgateway
+      enabled: true
+      k8s:
+        # Ingress gateway needs to have IPC_LOCK capability and the
+        # QAT resources manually added, because the template
+        # injection isn't supported for gateways.
+        overlays:
+        - kind: Deployment
+          name: istio-ingressgateway
+          patches:
+          - path: spec.template.spec.containers.[name:istio-proxy].securityContext.capabilities.add
+            value: [ "IPC_LOCK" ]
+        resources:
+          requests:
+            qat.intel.com/cy: '1'
+            qat.intel.com/dc: '1'
+            cpu: 2000m
+            memory: 4096Mi
+          limits:
+            qat.intel.com/cy: '1'
+            qat.intel.com/dc: '1'
+            cpu: 2000m
+            memory: 4096Mi
+        podAnnotations: # this controls the SDS service which configures ingress gateway
+          proxy.istio.io/config: |
+            privateKeyProvider:
+              qat:
+                pollDelay: 2ms
+
+  values:
+    # Annotate pods with either
+    #     inject.istio.io/templates: sidecar,qathw
+    sidecarInjectorWebhook:
+      templates:
+        qathw-crypto: |
+          spec:
+            containers:
+            - name: istio-proxy
+              securityContext:
+                capabilities:
+                  add:
+                  - IPC_LOCK
+              resources:
+                requests:
+                  qat.intel.com/cy: '1'
+                limits:
+                  qat.intel.com/cy: '1'
+        qathw-compression: |
+          spec:
+            containers:
+            - name: istio-proxy
+              securityContext:
+                capabilities:
+                  add:
+                  - IPC_LOCK
+              resources:
+                requests:
+                  qat.intel.com/dc: '1'
+                limits:
+                  qat.intel.com/dc: '1'


### PR DESCRIPTION
**Please provide a description of this PR:**

- Autogenerates a documentation site from the /intel directory and pushes it to the gh-pages branch. Someone with admin access needs to set Github pages to deploy from the gh-pages branch after merging. (preview of the docs site can be found [here](https://luukasmakila.github.io/istio/README.html))
- Added docs for cryptomb, was and sgx-mtls to the /intel/docs directory.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
