### PR TITLE
Port CI from 1.15 to 1.16

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+# Usage:
+# ./.github/workflows/build.sh 
+
+#first build should give permission to docker volumes
+#sudo chmod -R 777 /var/lib/docker/volumes
+
+set -e
+
+UPDATE_BRANCH=${UPDATE_BRANCH:-"master"}
+rm -rf istio-proxy
+git clone -b ${UPDATE_BRANCH} https://github.com/intel/istio-proxy.git
+
+pushd istio-proxy
+# Update to release branch as intel/envoy has updated.
+./scripts/update_envoy.sh
+BUILD_WITH_CONTAINER=1 make build_envoy 
+BUILD_WITH_CONTAINER=1 make exportcache
+popd
+
+# export env
+TAG=${TAG:-"pre-build"}
+make build
+# replace upstream envoy with local envoy in build proxyv2 image
+cp -rf istio-proxy/out/linux_amd64/envoy out/linux_amd64/release/envoy
+# build proxyv2 image
+make docker.proxyv2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,65 @@
+name: Build
+
+on:
+  push:
+    branches: [ release-*-intel ]
+    tags:
+    - '*'   
+  pull_request:
+    branches: [ release-*-intel ]
+
+env:
+  HUB: ghcr.io/${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: self-hosted
+    environment:
+      name: dev
+
+    env:
+      DOCKER_TARGETS: docker.pilot docker.istioctl docker.operator docker.install-cni
+      TAG: ${{ github.base_ref || github.ref_name }} 
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build Containers
+      run: |
+        make docker
+
+    - name: Build Container Proxyv2
+      run: |
+        ./.github/workflows/build.sh
+      env:
+        UPDATE_BRANCH: ${{ github.base_ref || github.ref_name }} 
+
+    - name: Login to the container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.HUB }}
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Push Containers
+      if: ${{ github.event_name == 'push' && github.ref_type != 'tag' }}
+      run: |
+        make push
+
+    - name: Push Container Proxyv2
+      if: ${{ github.event_name == 'push' && github.ref_type != 'tag' }}
+      run: |
+        docker push ${HUB}/proxyv2:${TAG}
+
+    - name: Push Containers With Tag
+      if: ${{ github.ref_type == 'tag' }}
+      run: |
+        make push
+      env:
+        TAG: ${{ github.ref_name }}
+
+    - name: Push Container Proxyv2 With Tag
+      if: ${{ github.ref_type == 'tag' }}
+      run: |
+        docker push ${HUB}/proxyv2:${TAG}
+      env:
+        TAG: ${{ github.ref_name }}


### PR DESCRIPTION
Signed-off-by: Xiao, Ziyang <ziyang.xiao@intel.com>

**Please provide a description of this PR:**
Since the gihub-hosted runner disk is too small to be used as a CI build runner, here we first use the self-hosted runner as an alternative


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
